### PR TITLE
Add project documentation links

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -172,6 +172,9 @@ export default function Dashboard() {
             <Link className="inline-action" to="/tags">
               Edit tag palette
             </Link>
+            <a className="inline-action" href="/readthedocs/" rel="noreferrer" target="_blank">
+              Browse project docs
+            </a>
             <a className="inline-action" href="/api/docs" rel="noreferrer" target="_blank">
               Browse API docs
             </a>

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -51,6 +51,14 @@ export default function AppShell() {
           <span className="app-user-badge">{user?.username || 'Authenticated user'}</span>
           <a
             className="site-nav-link"
+            href="/readthedocs/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Project docs
+          </a>
+          <a
+            className="site-nav-link"
             href="/api/docs"
             rel="noreferrer"
             target="_blank"

--- a/src/components/AppShell.test.jsx
+++ b/src/components/AppShell.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AppShell from './AppShell';
+
+const logout = vi.fn();
+
+vi.mock('../AuthProvider', () => ({
+  useAuth: () => ({
+    isAdmin: false,
+    logout,
+    user: { username: 'operator' },
+  }),
+}));
+
+vi.mock('../Dashboard', () => ({ default: () => <div>Dashboard</div> }));
+vi.mock('../Runes', () => ({ default: () => <div>Runes</div> }));
+vi.mock('../scrolls', () => ({ default: () => <div>Scrolls</div> }));
+vi.mock('../Tags', () => ({ default: () => <div>Tags</div> }));
+vi.mock('../Users', () => ({ default: () => <div>Users</div> }));
+
+describe('AppShell documentation links', () => {
+  beforeEach(() => {
+    logout.mockReset();
+  });
+
+  it('keeps project documentation separate from API documentation', () => {
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Project docs' })).toHaveAttribute(
+      'href',
+      '/readthedocs/',
+    );
+    expect(screen.getByRole('link', { name: 'API docs' })).toHaveAttribute(
+      'href',
+      '/api/docs',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add project documentation links to the application shell and dashboard
- keep project docs distinct from the FastAPI schema
- cover the navigation links with a component test

## Validation
- npm test
- npm run build